### PR TITLE
Add rule to match identifier targets with identifiers.

### DIFF
--- a/lib/aws-model-validators/resources_v1.rb
+++ b/lib/aws-model-validators/resources_v1.rb
@@ -133,5 +133,20 @@ module Aws::ModelValidators
       end
     end
 
+    # resource_identifier_target_must_match_identifiers
+    v(%w(
+      /resources/*/has/*/resource
+      /resources/*/hasMany/*/resource
+      /resources/*/actions/*/resource
+      /resources/*/batchActions/*/resource
+    )) do |c|
+      resource = c.resources['resources'][c.value['type']]
+      targets = c.value['identifiers'].map { |v| v['target'] }
+      identifiers = resource['identifiers'].map { |v| v['name'] }
+      unless targets == identifiers
+        c.error("identifier targets do not match #{c.value['type']} identifiers: #{targets} vs. #{identifiers}")
+      end
+    end
+
   end
 end

--- a/spec/resources_v1/resource_identifier_target_must_match_identifiers.json
+++ b/spec/resources_v1/resource_identifier_target_must_match_identifiers.json
@@ -1,0 +1,28 @@
+{
+  "resources": {
+    "resources": {
+      "Thing": {
+        "identifiers": [
+          { "name": "LastName" },
+          { "name": "FirstName" }
+        ],
+        "has": {
+          "SubThing": {
+            "resource": {
+              "type": "Thing",
+              "identifiers": [
+                {"target": "FirstName", "source": "input"},
+                {"target": "LastName", "source": "identifier", "name": "LastName"}
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "api": {
+  },
+  "errors": [
+    "/resources/Thing/has/SubThing/resource identifier targets do not match Thing identifiers: [\"FirstName\", \"LastName\"] vs. [\"LastName\", \"FirstName\"]"
+  ]
+}


### PR DESCRIPTION
This change adds a rule to ensure consistency between resource identifiers
used to build a response from an action, batch action, or collection and
the identifiers defined on the associated resource. It checks:
- Identifier count
- Identifier order

For example, given the following model:

``` json
{
    "Thing": {
        "identifiers": [
            {"name": "LastName"},
            {"name": "FirstName"}
        ]
    }
}
```

Any action, batch action, or collection which returns one or more instances
of this resource **must** provide those exact two identifiers as targets, in
the order given above (`LastName` first). Errors look like this:

```
/resources/MultipartUpload/has/Part/resource identifier targets do not match
MultipartUploadPart identifiers: ["BucketName", "MultipartUploadId",
"ObjectKey", "PartNumber"] vs. ["BucketName", "ObjectKey", "MultipartUploadId",
"PartNumber"]
```

cc @trevorrowe 
